### PR TITLE
Fix docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,11 +11,14 @@ services:
       MYSQL_PASSWORD: n3st_d4t4gr4ph
       MYSQL_DATABASE: nest_datagraph
     restart: always
+
   nestdatagraph:
     build:
       context: .
+    volumes:
+      - ./frontend/conf:/opt/nest-datagraph/frontend/conf
     ports:
-      - 80:8000
+      - 80:80
     links:
       - mariadb:mariadb
     environment:

--- a/frontend/conf/settings.ini.sample
+++ b/frontend/conf/settings.ini.sample
@@ -24,3 +24,11 @@ mysql_password = <MYSQL PASSWORD>
 mysql_hostname = <MYSQL IP>
 mysql_database = <MYSQL DATABASE>
 
+
+# If using docker-compose
+# [mysql]
+# mysql_username = nest_datagraph
+# mysql_password = n3st_d4t4gr4ph
+# mysql_hostname = mariadb
+# mysql_database = nest_datagraph
+


### PR DESCRIPTION
Noticed that config dir wasn't mounted and that the ports were different in the config file.  Also added the docker mysql password to the config sample.  Open to suggestions. 

It's probably best to include some vars that can be provided by env vars via docker if they dont already exist.